### PR TITLE
First attempt to add Decap CMS (previously Netlify CMS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 .jekyll-cache
+.DS_Store

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,4 @@
+backend:
+  name: github
+  repo: digpublishing/digpublishing.github.io
+  branch: master

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Content Manager</title>
+  </head>
+  <body>
+    <!-- Include the script that builds the page and powers Decap CMS -->
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
I'm seeing if a netlify account is required for github oauth to work. 
The docs are confusing on this.
If this works it should add Decap CMS to the`/admin` and allow oauth github login by anyone with repo access.
